### PR TITLE
Actually set the command to be executed

### DIFF
--- a/Exploit/Source/HackSysEVDExploit.c
+++ b/Exploit/Source/HackSysEVDExploit.c
@@ -256,7 +256,6 @@ INT main(UINT argc, PTCHAR argv[]) {
         "\t\t           ashfaq[at]payatu[dot]com            \t\n"
         "\t\t                                               \t\n";
 
-    PTCHAR commandToExecute = NULL;
     EXPLOIT_VULNERABILITY exploitVulnerability;
 
     ClearScreen();
@@ -268,6 +267,8 @@ INT main(UINT argc, PTCHAR argv[]) {
     if (argc < 3) {
         ShowUsage(argv[0]);
     }
+
+    exploitVulnerability.Command = argv[2];
 
     // Parse the command line arguments
     ARGBEGIN {


### PR DESCRIPTION
commandToExecute doesn't appear to be used anywhere and the actual 'Command' field in the struct doesn't appear to ever be set which causes CreateProcess() to always fail.