### PR TITLE
Add NULL check to error handling

### DIFF
--- a/Driver/Source/HackSysExtremeVulnerableDriver.c
+++ b/Driver/Source/HackSysExtremeVulnerableDriver.c
@@ -86,8 +86,10 @@ NTSTATUS DriverEntry(IN PDRIVER_OBJECT DriverObject, IN PUNICODE_STRING Registry
                             &DeviceObject);
 
     if (!NT_SUCCESS(Status)) {
-        // Delete the device
-        IoDeleteDevice(DriverObject->DeviceObject);
+        if (DriverObject->DeviceObject) {
+            // Delete the device
+            IoDeleteDevice(DriverObject->DeviceObject);
+        }
 
         DbgPrint("[-] Error Initializing HackSys Extreme Vulnerable Driver\n");
         return Status;


### PR DESCRIPTION
It is possible for IoCreateDevice to fail and leave DriverObject->DeviceObject as NULL which will cause a bug check when passed to IoDeleteDevice.