### PR TITLE
Type confusion x64

### DIFF
--- a/Driver/TypeConfusion.h
+++ b/Driver/TypeConfusion.h
@@ -55,14 +55,14 @@ Abstract:
     #include "Common.h"
 
     typedef struct _USER_TYPE_CONFUSION_OBJECT {
-      ULONG_PTR ObjectID;
-      ULONG_PTR ObjectType;
+        ULONG_PTR ObjectID;
+        ULONG_PTR ObjectType;
     } USER_TYPE_CONFUSION_OBJECT, *PUSER_TYPE_CONFUSION_OBJECT;
   
     typedef struct _KERNEL_TYPE_CONFUSION_OBJECT {
-      ULONG_PTR ObjectID;
+        ULONG_PTR ObjectID;
         union {
-      ULONG_PTR ObjectType;
+            ULONG_PTR ObjectType;
             FunctionPointer Callback;
         };
     } KERNEL_TYPE_CONFUSION_OBJECT, *PKERNEL_TYPE_CONFUSION_OBJECT;

--- a/Driver/TypeConfusion.h
+++ b/Driver/TypeConfusion.h
@@ -55,14 +55,14 @@ Abstract:
     #include "Common.h"
 
     typedef struct _USER_TYPE_CONFUSION_OBJECT {
-        ULONG ObjectID;
-        ULONG ObjectType;
+      ULONG_PTR ObjectID;
+      ULONG_PTR ObjectType;
     } USER_TYPE_CONFUSION_OBJECT, *PUSER_TYPE_CONFUSION_OBJECT;
-
+  
     typedef struct _KERNEL_TYPE_CONFUSION_OBJECT {
-        ULONG ObjectID;
+      ULONG_PTR ObjectID;
         union {
-            ULONG ObjectType;
+      ULONG_PTR ObjectType;
             FunctionPointer Callback;
         };
     } KERNEL_TYPE_CONFUSION_OBJECT, *PKERNEL_TYPE_CONFUSION_OBJECT;


### PR DESCRIPTION
Thought it'd be nice to make this possible on x64:
>
>****** HACKSYS_EVD_IOCTL_TYPE_CONFUSION ******
>[+] Pool Tag: 'kcaH'
>[+] Pool Type: NonPagedPool
>[+] Pool Size: 0x10
>[+] Pool Chunk: 0xFFFFC48C45D38D90
>[+] UserTypeConfusionObject: 0x000002C9012CC650
>[+] KernelTypeConfusionObject: 0xFFFFC48C45D38D90
>[+] KernelTypeConfusionObject Size: 0x10
>[+] KernelTypeConfusionObject->ObjectID: 0x4141414141414141
>[+] KernelTypeConfusionObject->ObjectType: 0x4141414141414141
>[+] Triggering Type Confusion
>[+] KernelTypeConfusionObject->Callback: 0x4141414141414141
>[+] Calling Callback
>[-] Exception Code: 0xC0000005
>****** HACKSYS_EVD_IOCTL_TYPE_CONFUSION ******
>