### PR TITLE
Ported integer overflow vulnerability module to Linux

### DIFF
--- a/Driver/HEVD/Linux/CMakeLists.txt
+++ b/Driver/HEVD/Linux/CMakeLists.txt
@@ -10,5 +10,5 @@ lkm_add_driver(
         HEVD
     HackSysExtremeVulnerableDriver.c
     BufferOverflowStack.c
-	IntegerOverflow.c
+    IntegerOverflow.c
 )

--- a/Driver/HEVD/Linux/CMakeLists.txt
+++ b/Driver/HEVD/Linux/CMakeLists.txt
@@ -10,4 +10,5 @@ lkm_add_driver(
         HEVD
     HackSysExtremeVulnerableDriver.c
     BufferOverflowStack.c
+	IntegerOverflow.c
 )

--- a/Driver/HEVD/Linux/HackSysExtremeVulnerableDriver.c
+++ b/Driver/HEVD/Linux/HackSysExtremeVulnerableDriver.c
@@ -49,27 +49,22 @@ Abstract:
 
 #include "HackSysExtremeVulnerableDriver.h"
 
-
 /**
  * File Operations
  */
 
 struct file_operations hevd_fops = {
-	.owner = THIS_MODULE,
-	.unlocked_ioctl = hevd_ioctl
-};
-
+    .owner = THIS_MODULE,
+    .unlocked_ioctl = hevd_ioctl};
 
 /**
  * Miscellaneous Device
  */
 
 static struct miscdevice hevd_device = {
-	.minor = MISC_DYNAMIC_MINOR,
-	.name = "HackSysExtremeVulnerableDriver",
-	.fops = &hevd_fops
-};
-
+    .minor = MISC_DYNAMIC_MINOR,
+    .name = "HackSysExtremeVulnerableDriver",
+    .fops = &hevd_fops};
 
 /**
  * Driver initialization routine
@@ -78,70 +73,67 @@ static struct miscdevice hevd_device = {
  */
 static int __init hevd_init(void)
 {
-	int status = 0;
+    int status = 0;
 
-	/**
+    /**
      * Register the device
      */
 
-	status = misc_register(&hevd_device);
+    status = misc_register(&hevd_device);
 
-	if (status < 0)
-	{
-		ERR("[-] Error Initializing HackSys Extreme Vulnerable Driver\n");
-		return status;
-	}
+    if (status < 0)
+    {
+        ERR("[-] Error Initializing HackSys Extreme Vulnerable Driver\n");
+        return status;
+    }
 
-	INFO(BANNER);
-	INFO("[+] HackSys Extreme Vulnerable Driver Loaded\n");
+    INFO(BANNER);
+    INFO("[+] HackSys Extreme Vulnerable Driver Loaded\n");
 
-	return status;
+    return status;
 }
-
 
 /**
  * Driver cleanup routine
  */
 static void __exit hevd_exit(void)
 {
-	/**
+    /**
      * Deregister the device
      */
 
-	misc_deregister(&hevd_device);
+    misc_deregister(&hevd_device);
 
-	INFO("[-] HackSys Extreme Vulnerable Driver Unloaded\n");
+    INFO("[-] HackSys Extreme Vulnerable Driver Unloaded\n");
 }
-
 
 /**
  * Driver IOCTL handler
  */
 static long hevd_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 {
-	int status = -EINVAL;
-	void __user *arg_user = (void __user *)arg;
+    int status = -EINVAL;
+    void __user *arg_user = (void __user *)arg;
 
-	switch (cmd)
-	{
-	case HEVD_IOCTL_BUFFER_OVERFLOW_STACK:
-		INFO("****** HEVD_IOCTL_BUFFER_OVERFLOW_STACK ******\n");
-		status = buffer_overflow_stack_ioctl_handler(arg_user);
-		INFO("****** HEVD_IOCTL_BUFFER_OVERFLOW_STACK ******\n");
-	case HEVD_IOCTL_INTEGER_OVERFLOW:
-		INFO("****** HEVD_IOCTL_INTEGER_OVERFLOW ******\n");
-		status = integer_overflow_ioctl_handler(arg_user);
-		INFO("****** HEVD_IOCTL_INTEGER_OVERFLOW ******\n");
-		break;
-	default:
-		WARNING("[-] Invalid IOCTL Code: 0x%X\n", cmd);
-		status = -ENOIOCTLCMD;
-		break;
-	}
+    switch (cmd)
+    {
+    case HEVD_IOCTL_BUFFER_OVERFLOW_STACK:
+        INFO("****** HEVD_IOCTL_BUFFER_OVERFLOW_STACK ******\n");
+        status = buffer_overflow_stack_ioctl_handler(arg_user);
+        INFO("****** HEVD_IOCTL_BUFFER_OVERFLOW_STACK ******\n");
+    case HEVD_IOCTL_INTEGER_OVERFLOW:
+        INFO("****** HEVD_IOCTL_INTEGER_OVERFLOW ******\n");
+        status = integer_overflow_ioctl_handler(arg_user);
+        INFO("****** HEVD_IOCTL_INTEGER_OVERFLOW ******\n");
+        break;
+    default:
+        WARNING("[-] Invalid IOCTL Code: 0x%X\n", cmd);
+        status = -ENOIOCTLCMD;
+        break;
+    }
 
-	return status;
+    return status;
 }
-
 
 /**
  * Set initialization and cleanup routines
@@ -149,7 +141,6 @@ static long hevd_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 
 module_init(hevd_init);
 module_exit(hevd_exit);
-
 
 /**
  * Module information

--- a/Driver/HEVD/Linux/HackSysExtremeVulnerableDriver.c
+++ b/Driver/HEVD/Linux/HackSysExtremeVulnerableDriver.c
@@ -55,7 +55,8 @@ Abstract:
 
 struct file_operations hevd_fops = {
     .owner = THIS_MODULE,
-    .unlocked_ioctl = hevd_ioctl};
+    .unlocked_ioctl = hevd_ioctl
+};
 
 /**
  * Miscellaneous Device
@@ -64,7 +65,8 @@ struct file_operations hevd_fops = {
 static struct miscdevice hevd_device = {
     .minor = MISC_DYNAMIC_MINOR,
     .name = "HackSysExtremeVulnerableDriver",
-    .fops = &hevd_fops};
+    .fops = &hevd_fops
+};
 
 /**
  * Driver initialization routine

--- a/Driver/HEVD/Linux/HackSysExtremeVulnerableDriver.c
+++ b/Driver/HEVD/Linux/HackSysExtremeVulnerableDriver.c
@@ -73,7 +73,7 @@ static struct miscdevice hevd_device = {
 
 /**
  * Driver initialization routine
- * 
+ *
  * @return status code
  */
 static int __init hevd_init(void)
@@ -126,8 +126,12 @@ static long hevd_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 	{
 	case HEVD_IOCTL_BUFFER_OVERFLOW_STACK:
 		INFO("****** HEVD_IOCTL_BUFFER_OVERFLOW_STACK ******\n");
-        status = buffer_overflow_stack_ioctl_handler(arg_user);
-        INFO("****** HEVD_IOCTL_BUFFER_OVERFLOW_STACK ******\n");
+		status = buffer_overflow_stack_ioctl_handler(arg_user);
+		INFO("****** HEVD_IOCTL_BUFFER_OVERFLOW_STACK ******\n");
+	case HEVD_IOCTL_INTEGER_OVERFLOW:
+		INFO("****** HEVD_IOCTL_INTEGER_OVERFLOW ******\n");
+		status = integer_overflow_ioctl_handler(arg_user);
+		INFO("****** HEVD_IOCTL_INTEGER_OVERFLOW ******\n");
 		break;
 	default:
 		WARNING("[-] Invalid IOCTL Code: 0x%X\n", cmd);

--- a/Driver/HEVD/Linux/IntegerOverflow.c
+++ b/Driver/HEVD/Linux/IntegerOverflow.c
@@ -1,0 +1,129 @@
+/*++
+
+          ##     ## ######## ##     ## ########
+          ##     ## ##       ##     ## ##     ##
+          ##     ## ##       ##     ## ##     ##
+          ######### ######   ##     ## ##     ##
+          ##     ## ##        ##   ##  ##     ##
+          ##     ## ##         ## ##   ##     ##
+          ##     ## ########    ###    ########
+
+            HackSys Extreme Vulnerable Driver
+
+Author : Ashfaq Ansari
+Contact: ashfaq[at]payatu[dot]com
+Website: http://www.payatu.com/
+
+Copyright (C) 2015-2020 Payatu Software Labs LLP. All rights reserved.
+
+This program is free software: you can redistribute it and/or modify it under the terms of
+the GNU General Public License as published by the Free Software Foundation, either version
+3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program.
+If not, see <http://www.gnu.org/licenses/>.
+
+THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+See the file 'LICENSE' for complete copying permission.
+
+Module Name:
+    IntegerOverlfow.c
+
+Abstract:
+    This module implements the functions to demonstrate
+    integer overflow in kernel module
+
+--*/
+
+#include "IntegerOverflow.h"
+
+
+/**
+ * @param user_buffer the pointer to user mode buffer
+ * @param size size of the user mode buffer
+ */
+int trigger_integer_overflow(void *user_buffer, size_t size)
+{
+    int status = -EINVAL;
+    unsigned int count = 0;
+    unsigned int kernel_buffer[BUFFER_SIZE] = { 0 };
+    unsigned int kernel_buffer_terminator = 0xBAD0B0B0;
+    unsigned int terminator_size = sizeof(kernel_buffer_terminator);
+
+    INFO("[+] user_buffer: 0x%p\n", user_buffer);
+    INFO("[+] user_buffer size: 0x%zX\n", size);
+    INFO("[+] kernel_buffer: 0x%p\n", &kernel_buffer);
+    INFO("[+] kernel_buffer size: 0x%zX\n", sizeof(kernel_buffer));
+
+#ifdef SECURE
+    //
+    // Secure Note: This is secure because the developer is not doing any arithmetic
+    // on the user supplied value. Instead, the developer is subtracting the size of
+    // UINT i.e. 4 on x86 from the size of KernelBuffer. Hence, integer overflow will
+    // not occur and this check will not fail
+    //
+    if (size > (sizeof(kernel_buffer) - terminator_size)) {
+        ERR("[-] Invalid user buffer size: 0x%zX\n", size);
+        return status;
+    }
+
+#else
+    INFO("[+] Triggering Integer Overflow\n");
+    //
+    // Vulnerability Note: This is a vanilla Integer Overflow vulnerability because if
+    // 'Size' is 0xFFFFFFFF and we do an addition with size of ULONG i.e. 4 on x86, the
+    // integer will wrap down and will finally cause this check to fail
+    //
+    if ((size + terminator_size) > sizeof(kernel_buffer)) {
+        ERR("[-] Invalid user buffer size: 0x%zX\n", size);
+        return status;
+    }
+#endif
+
+    while (count < (size / sizeof(unsigned long))) {
+        unsigned int n;
+
+        copy_from_user((void*) &n, user_buffer + count, sizeof(n));
+        if (n == kernel_buffer_terminator)
+                break;
+
+        kernel_buffer[count++] = n;
+    }
+
+
+    return status;
+}
+
+
+/**
+ * @param[in] io user space buffer
+ * @return status code
+ */
+int integer_overflow_ioctl_handler(struct hevd_io *io)
+{
+    size_t size = 0;
+    void *user_buffer = NULL;
+    int status = -EINVAL;
+
+    user_buffer = io->input_buffer;
+    size = io->input_buffer_length;
+
+    if (user_buffer)
+    {
+        status = trigger_integer_overflow(user_buffer, size);
+    }
+
+    return status;
+}

--- a/Driver/HEVD/Linux/IntegerOverflow.c
+++ b/Driver/HEVD/Linux/IntegerOverflow.c
@@ -92,7 +92,7 @@ int trigger_integer_overflow(void *user_buffer, size_t size)
     }
 #endif
 
-    while (count < (size / sizeof(unsigned long))) {
+    while (count < (size / sizeof(unsigned int))) {
         unsigned int n;
 
         copy_from_user((void*) &n, user_buffer + count, sizeof(n));

--- a/Driver/HEVD/Linux/IntegerOverflow.c
+++ b/Driver/HEVD/Linux/IntegerOverflow.c
@@ -1,12 +1,12 @@
 /*++
 
-          ##     ## ######## ##     ## ########
-          ##     ## ##       ##     ## ##     ##
-          ##     ## ##       ##     ## ##     ##
-          ######### ######   ##     ## ##     ##
-          ##     ## ##        ##   ##  ##     ##
-          ##     ## ##         ## ##   ##     ##
-          ##     ## ########    ###    ########
+        ##     ## ######## ##     ## ########
+        ##     ## ##       ##     ## ##     ##
+        ##     ## ##       ##     ## ##     ##
+        ######### ######   ##     ## ##     ##
+        ##     ## ##        ##   ##  ##     ##
+        ##     ## ##         ## ##   ##     ##
+        ##     ## ########    ###    ########
 
             HackSys Extreme Vulnerable Driver
 
@@ -49,7 +49,6 @@ Abstract:
 
 #include "IntegerOverflow.h"
 
-
 /**
  * @param user_buffer the pointer to user mode buffer
  * @param size size of the user mode buffer
@@ -58,7 +57,7 @@ int trigger_integer_overflow(void *user_buffer, size_t size)
 {
     int status = -EINVAL;
     unsigned int count = 0;
-    unsigned int kernel_buffer[BUFFER_SIZE] = { 0 };
+    unsigned int kernel_buffer[BUFFER_SIZE] = {0};
     unsigned int kernel_buffer_terminator = 0xBAD0B0B0;
     unsigned int terminator_size = sizeof(kernel_buffer_terminator);
 
@@ -74,7 +73,8 @@ int trigger_integer_overflow(void *user_buffer, size_t size)
     // UINT i.e. 4 on x86 from the size of KernelBuffer. Hence, integer overflow will
     // not occur and this check will not fail
     //
-    if (size > (sizeof(kernel_buffer) - terminator_size)) {
+    if (size > (sizeof(kernel_buffer) - terminator_size))
+    {
         ERR("[-] Invalid user buffer size: 0x%zX\n", size);
         return status;
     }
@@ -86,26 +86,26 @@ int trigger_integer_overflow(void *user_buffer, size_t size)
     // 'Size' is 0xFFFFFFFF and we do an addition with size of ULONG i.e. 4 on x86, the
     // integer will wrap down and will finally cause this check to fail
     //
-    if ((size + terminator_size) > sizeof(kernel_buffer)) {
+    if ((size + terminator_size) > sizeof(kernel_buffer))
+    {
         ERR("[-] Invalid user buffer size: 0x%zX\n", size);
         return status;
     }
 #endif
 
-    while (count < (size / sizeof(unsigned int))) {
+    while (count < (size / sizeof(unsigned int)))
+    {
         unsigned int n;
 
-        copy_from_user((void*) &n, user_buffer + count, sizeof(n));
+        copy_from_user((void *)&n, user_buffer + count, sizeof(n));
         if (n == kernel_buffer_terminator)
-                break;
+            break;
 
         kernel_buffer[count++] = n;
     }
 
-
     return status;
 }
-
 
 /**
  * @param[in] io user space buffer

--- a/Driver/HEVD/Linux/IntegerOverflow.h
+++ b/Driver/HEVD/Linux/IntegerOverflow.h
@@ -39,62 +39,27 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 See the file 'LICENSE' for complete copying permission.
 
 Module Name:
-    Common.h
+    IntegerOverflow.h
 
 Abstract:
-    This module implements the data structures which
-    are common to the driver modules.
+    This module implements the data structures for
+    integer overflow module.
 
 --*/
 
 #pragma once
 
-#ifndef __COMMON_H__
-#define __COMMON_H__
+#ifndef __INTEGER_OVERFLOW_H__
+#define __INTEGER_OVERFLOW_H__
 
-#include <linux/fs.h>
-#include <linux/init.h>
-#include <linux/kernel.h>
-#include <linux/module.h>
-#include <linux/uaccess.h>
-#include <linux/miscdevice.h>
-
-
-/**
- * Defines
- */
-
-#define BUFFER_SIZE 512
-
-#define _STRINGIFY(value) #value
-#define STRINGIFY(value) _STRINGIFY(value)
-
-#define PRINTK(level, fmt, ...) printk(KERN_##level "%s: " fmt, THIS_MODULE->name, ##__VA_ARGS__)
-
-#define ERR(fmt, ...) PRINTK(ERR, fmt, ##__VA_ARGS__)
-#define INFO(fmt, ...) PRINTK(INFO, fmt, ##__VA_ARGS__)
-#define WARNING(fmt, ...) PRINTK(WARNING, fmt, ##__VA_ARGS__)
-
-typedef void (*FunctionPointer)(void);
-
-
-/**
- * Structures
- */
-
-struct hevd_io {
-    void *input_buffer;
-    size_t input_buffer_length;
-    void *output_buffer;
-    size_t output_buffer_length;
-};
+#include "Common.h"
 
 
 /**
  * Function Definitions
  */
 
-int buffer_overflow_stack_ioctl_handler(struct hevd_io *io);
-int integer_overflow_ioctl_handler(struct hevd_io *io);
+int trigger_integer_overflow(void *user_buffer, size_t size);
 
-#endif // !__COMMON_H__
+#endif
+

--- a/Driver/HEVD/Linux/IntegerOverflow.h
+++ b/Driver/HEVD/Linux/IntegerOverflow.h
@@ -54,7 +54,6 @@ Abstract:
 
 #include "Common.h"
 
-
 /**
  * Function Definitions
  */
@@ -62,4 +61,3 @@ Abstract:
 int trigger_integer_overflow(void *user_buffer, size_t size);
 
 #endif
-


### PR DESCRIPTION
Ported integer overflow vulnerability module from Windows driver to Linux LKM.

Changed `unsigned long` to `unsigned int` to guarantee 4 bytes data type irrespective of x86/x86_64 on Linux.