### PR TITLE
double fetch bug in the secure WriteNULL

### DIFF
--- a/Driver/HEVD/Windows/WriteNULL.c
+++ b/Driver/HEVD/Windows/WriteNULL.c
@@ -87,10 +87,10 @@ TriggerWriteNULL(
         // '*(UserBuffer)' resides in User mode by calling ProbeForWrite() routine before
         // performing the write operation
         //
+		PVOID * UserPointerToNullify = *(PVOID *)UserBuffer; 
+        ProbeForWrite(UserPointerToNullify, sizeof(PVOID), (ULONG)__alignof(PVOID));
 
-        ProbeForWrite(*(PVOID *)UserBuffer, sizeof(PVOID), (ULONG)__alignof(PVOID));
-
-        **(PVOID **)UserBuffer = NULL;
+        *(PVOID *)UserPointerToNullify = NULL;
 #else
         DbgPrint("[+] Triggering Arbitrary NULL Write\n");
 


### PR DESCRIPTION
it checks the address to write into from UserBuffer, then reads the address again from the buffer
The address inside UserBuffer can be changed (from another thread) right after ProbeForWrite, just before the actual write

The bug is hard to reproduce since the time slot is really small
Easiest way to reproduce is to create a delay after ProbeForWrite, giving enough time for the second thread to change the address.