### PR TITLE
Fix Size type in IntegerOverflow

### DIFF
--- a/Driver/HEVD/Windows/IntegerOverflow.c
+++ b/Driver/HEVD/Windows/IntegerOverflow.c
@@ -65,14 +65,14 @@ __declspec(safebuffers)
 NTSTATUS
 TriggerIntegerOverflow(
     _In_ PVOID UserBuffer,
-    _In_ SIZE_T Size
+    _In_ ULONG Size
 )
 {
     ULONG Count = 0;
     NTSTATUS Status = STATUS_SUCCESS;
     ULONG BufferTerminator = 0xBAD0B0B0;
     ULONG KernelBuffer[BUFFER_SIZE] = { 0 };
-    SIZE_T TerminatorSize = sizeof(BufferTerminator);
+    ULONG TerminatorSize = sizeof(BufferTerminator);
 
     PAGED_CODE();
 
@@ -163,7 +163,7 @@ IntegerOverflowIoctlHandler(
 )
 {
     PVOID UserBuffer = NULL;
-    SIZE_T Size = 0;
+    ULONG Size = 0;
     NTSTATUS Status = STATUS_UNSUCCESSFUL;
 
     UNREFERENCED_PARAMETER(Irp);

--- a/Driver/HEVD/Windows/IntegerOverflow.h
+++ b/Driver/HEVD/Windows/IntegerOverflow.h
@@ -62,7 +62,7 @@ Abstract:
 NTSTATUS
 TriggerIntegerOverflow(
     _In_ PVOID UserBuffer,
-    _In_ SIZE_T Size
+    _In_ ULONG Size
 );
 
 #endif  // !__INTEGER_OVERFLOW_H__


### PR DESCRIPTION
SIZE_T is defined as ULONG_PTR.
ULONG_PTR is defined as unsigned long on x86, but as unsigned __int64 on x64.
Also InputBufferLength is defined as ULONG(unsigned long) on x86 and x64.

So when InputBufferLength is copied to Size in a driver built on x64, an implicit type conversion occurs and it becomes unsigned __int64 type, so even if InputBufferLength is passed 0xFFFFFFFF, it is still an integer overflow will not occur.

This pull request is to fix the issue.