### PR TITLE
Add write-up references for windows 10 64bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ External Blog Posts
 
 [https://glennmcgui.re/introduction-to-windows-kernel-driver-exploitation-pt-2/](https://glennmcgui.re/introduction-to-windows-kernel-driver-exploitation-pt-2/)
 
+[https://kristal-g.github.io/2021/02/07/HEVD_StackOverflowGS_Windows_10_RS5_x64.html](https://kristal-g.github.io/2021/02/07/HEVD_StackOverflowGS_Windows_10_RS5_x64.html)
+
+[https://kristal-g.github.io/2021/02/20/HEVD_Type_Confusion_Windows_10_RS5_x64.html](https://kristal-g.github.io/2021/02/20/HEVD_Type_Confusion_Windows_10_RS5_x64.html)
+
 
 Author
 ------


### PR DESCRIPTION
Added write-up references for type confusion and StackOverflowGS for windows 10 x64.
Haven't seen other solutions like these so I thought it will be good to have it referenced here