### PR TITLE
Explicitly specify sha1 digest algorithm when signing

### DIFF
--- a/Driver/CMake/WDK.cmake
+++ b/Driver/CMake/WDK.cmake
@@ -224,7 +224,7 @@ function(wdk_add_driver _target)
     if(EXISTS ${PROJECT_PFX_PATH})
         # signtool.exe Configuration
         set(SIGNTOOL_PATH "${WDK_ROOT}/bin/${WDK_VERSION}/x86/signtool.exe")
-        set(SIGNTOOL_ARGS "sign /f \"${PROJECT_PFX_PATH}\" /p ${WDK_PFX_PASSWORD}")
+        set(SIGNTOOL_ARGS "sign /fd sha1 /f \"${PROJECT_PFX_PATH}\" /p ${WDK_PFX_PASSWORD}")
 
         add_custom_command(
           COMMENT "Signing driver binary file"


### PR DESCRIPTION
When trying to building the x64 vulnerable driver (by running `Build_HEVD_Vulnerable_x64.bat`) I got the following error:

```
Stamping [Version] section with DriverVer=12/28/2024,3.0.0.0
SignTool Error: No file digest algorithm specified. Please specify the digest algorithm with the /fd flag. Using /fd SHA256 is recommended and more secure than SHA1. Calling signtool with /fd sha1 is equivalent to the previous behavior. In order to select the hash algorithm used in the signing certificate's signature, use the /fd certHash option.
ninja: build stopped: subcommand failed.

[+] Copying built files
[*] HEVD.sys
        1 file(s) moved.
[*] HEVD.pdb
        1 file(s) moved.
[*] HEVD.cat
The system cannot find the file specified.
```

The driver built just fine, but the `HEVD.cat` file was not generated.
For reference, I ran this inside a Windows 10 VM (22H2, build 19045.3803), using WDK 10.0.26100.2454 and Visual Studio 2022 (I couldn't find a way to download the older Visual Studio 2017 from MS's website).

As the error message suggests, `signtool` seems to require a digest algorithm to be specified. After setting the algorithm to `sha1` in order to retain compatibility with old behavior, I was able to build it just fine.