### PR TITLE
Fix status value in UaF object allocation functions. As it stands it …

### DIFF
--- a/Driver/HEVD/Windows/UseAfterFreeNonPagedPool.c
+++ b/Driver/HEVD/Windows/UseAfterFreeNonPagedPool.c
@@ -89,7 +89,7 @@ AllocateUaFObjectNonPagedPool(
     VOID
 )
 {
-    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    NTSTATUS Status = STATUS_SUCCESS;
     PUSE_AFTER_FREE_NON_PAGED_POOL UseAfterFree = NULL;
 
     PAGED_CODE();

--- a/Driver/HEVD/Windows/UseAfterFreeNonPagedPoolNx.c
+++ b/Driver/HEVD/Windows/UseAfterFreeNonPagedPoolNx.c
@@ -89,7 +89,7 @@ AllocateUaFObjectNonPagedPoolNx(
     VOID
 )
 {
-    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    NTSTATUS Status = STATUS_SUCCESS;
     PUSE_AFTER_FREE_NON_PAGED_POOL_NX UseAfterFree = NULL;
 
     PAGED_CODE();


### PR DESCRIPTION
…always returns STATUS_UNSUCCESSFUL even if no error exists